### PR TITLE
feat: add subcommand 'connect'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ ipgw info -a
 ipgw test
 ```
 
+WLAN 连接到 NEU 
+
+```shell
+ipgw connect
+```
+
+连接到名为 mywlan 的无线网络
+```shell
+ipgw connect wywlan
+```
+
 更新工具
 
 ```shell

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+
 	"github.com/neucn/ipgw/pkg/console"
 	"github.com/neucn/ipgw/pkg/handler"
 	"github.com/urfave/cli/v2"
@@ -22,6 +23,7 @@ var (
 			TestCommand,
 			VersionCommand,
 			UpdateCommand,
+			ConnectCommand,
 		},
 		Action: func(ctx *cli.Context) error {
 			if ctx.NArg() != 0 {

--- a/pkg/cmd/connect.go
+++ b/pkg/cmd/connect.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"os/exec"
+
+	"github.com/neucn/ipgw/pkg/console"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	ConnectCommand = &cli.Command{
+		Name:      "connect",
+		Usage:     "connect to a WLAN with a specific SSID, default NEU",
+		ArgsUsage: "[WLAN SSID]",
+		Action: func(ctx *cli.Context) error {
+			sids := ctx.Args().Slice()
+			if len(sids) > 1 {
+				console.InfoL("wrong arguments!")
+				return nil
+			}
+			ssid := "NEU"
+			if len(sids) == 1 {
+				ssid = sids[0]
+			}
+			console.InfoL("Connecting...")
+			out, err := exec.Command("powershell", "netsh wlan connect name="+ssid).Output()
+			if err != nil {
+				console.InfoF("connect failed. Details: %s\n", err.Error())
+			}
+			if out != nil {
+				console.InfoF(string(out))
+			}
+			return nil
+		},
+	}
+)


### PR DESCRIPTION
## 新增特性
新增命令 “ipgw connect <SSID>”, 用法见 README.md 或 help, SSID 默认值为 NEU。

## 背景
部分同学电脑打开不会自动连接 NEU，或需要在手机热点和 NEU 校园网之间切换（比如我自己... 新生用了个免费的校园网套餐，这个月还不能改，流量完全不够用）。 特增加此命令方便使用。

## 环境
仅在 windows10 下测试有效。
