### PR TITLE
[fix] 适配新版校园网关

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,20 @@
 
 <p align="center"><a href="#安装">安装</a> | <a href="#快速开始">快速开始</a> | <a href="https://github.com/neucn/ipgw/issues/new">反馈</a></p>
 
-
 # 安装
 
 ## Windows
+
 在 Powershell 中执行以下命令安装
+
 ```powershell
 iwr https://raw.githubusercontent.com/neucn/ipgw/master/install.ps1 -useb | iex
 ```
 
 ## Linux/FreeBSD/OSX
+
 在 shell 中执行以下命令安装
+
 ```shell
 curl -fsSL https://raw.githubusercontent.com/neucn/ipgw/master/install.sh | sh
 ```
@@ -35,20 +38,13 @@ curl -fsSL https://raw.githubusercontent.com/neucn/ipgw/master/install.sh | sh
 # 快速开始
 
 > 须知：本项目的最初目的仅在于满足作者本人的日常使用，因此工具的输出文本中同时存在中英文。
-> 
+>
 > 欢迎有兴趣的同学提起 [Pull Request](https://github.com/neucn/ipgw/pulls) 将输出文本统一为中文 😀
-
 
 保存 ipgw 账号 (密码将被加密存储)
 
 ```shell
 ipgw config account add -u "学号" -p "密码" --default
-```
-
-如果账号密码是非统一认证方式下的，请加上 `-o` (old) 参数
-
-```shell
-ipgw config account add -u "学号" -p "密码" -o --default
 ```
 
 使用默认账号快速登录，需要先保存至少一个 ipgw 账号在本地
@@ -82,4 +78,3 @@ ipgw update
 ```
 
 更多命令及其可配置项请使用 `ipgw help` 与 `ipgw help [command name]` 查看
-

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -41,17 +41,12 @@ var (
 				Name:     "password",
 				Aliases:  []string{"p"},
 				Required: true,
-				Usage:    "`password` for pass.neu.edu.cn or ipgw.neu.edu.cn if use old login method",
+				Usage:    "`password` for pass.neu.edu.cn",
 			},
 			&cli.StringFlag{
 				Name:    "secret",
 				Aliases: []string{"s"},
 				Usage:   "`secret` for stored account",
-			},
-			&cli.BoolFlag{
-				Name:    "old",
-				Aliases: []string{"o"},
-				Usage:   "use old login method (non-unified)",
 			},
 			&cli.BoolFlag{
 				Name:  "default",
@@ -68,8 +63,7 @@ var (
 			if err = store.Config.AddAccount(
 				username,
 				password,
-				ctx.String("secret"),
-				ctx.Bool("old")); err != nil {
+				ctx.String("secret")); err != nil {
 				return fmt.Errorf("fail to add account:\n\t%v", err)
 			}
 
@@ -135,11 +129,6 @@ var (
 				Name:    "secret",
 				Aliases: []string{"s"},
 				Usage:   "new `secret` for stored account, must be used with --password, -p",
-			},
-			&cli.BoolFlag{
-				Name:    "old",
-				Aliases: []string{"o"},
-				Usage:   "use old login method (non-unified)",
 			},
 			&cli.BoolFlag{
 				Name:  "default",

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/neucn/ipgw/pkg/console"
 	"github.com/urfave/cli/v2"
 )
@@ -161,10 +162,6 @@ var (
 				if err = account.SetPassword(ctx.String("password"), []byte(ctx.String("secret"))); err != nil {
 					return fmt.Errorf("fail to set account:\n\t'%s' not found", username)
 				}
-			}
-
-			if ctx.IsSet("old") {
-				account.NonUnified = ctx.Bool("old")
 			}
 
 			if ctx.Bool("default") {

--- a/pkg/cmd/info.go
+++ b/pkg/cmd/info.go
@@ -3,11 +3,11 @@ package cmd
 import (
 	"errors"
 	"fmt"
+
 	"github.com/neucn/ipgw/pkg/console"
 	"github.com/neucn/ipgw/pkg/handler"
 	"github.com/neucn/ipgw/pkg/model"
 	"github.com/urfave/cli/v2"
-	"strings"
 )
 
 var (
@@ -130,18 +130,14 @@ func (i *infoPrinter) PrintPackage() {
 		console.InfoL("\t获取失败")
 		return
 	}
-	status := make([]string, 0, 2)
+	var status string
 	if pkg.Overdue {
-		status = append(status, "已欠费")
+		status = "已欠费"
+	} else {
+		status = "正常"
 	}
-	if pkg.ExcessPackageTraffic {
-		status = append(status, "流量超额")
-	}
-	if len(status) == 0 {
-		status = append(status, "正常")
-	}
-	console.InfoF("\t套餐\t%sG / %sR\n\t已用\t%s\n\t时长\t%s\n\t次数\t%s\n\t余额\t%sR\n\t状态\t%s\n",
-		pkg.PackageTraffic, pkg.PackageCost, pkg.UsedTraffic, pkg.UsedDuration, pkg.UsedTimes, pkg.Balance, strings.Join(status, " "))
+	console.InfoF("\t已用\t%s\n\t时长\t%s\n\t消费\t%sR\n\t余额\t%sR\n\t状态\t%s\n",
+		pkg.UsedTraffic, pkg.UsedDuration, pkg.PackageCost, pkg.Balance, status)
 }
 
 func (i *infoPrinter) PrintDevices() {
@@ -166,7 +162,7 @@ func (i *infoPrinter) PrintRecharges(page int) {
 		return
 	}
 	for _, record := range records {
-		console.InfoF("\t#%8s\t%s\t%sR\t%s\n", record.ID, record.Time, record.Cost, record.Method)
+		console.InfoF("\t#%8s\t%s\t%sR\n", record.ID, record.Time, record.Cost)
 	}
 }
 
@@ -192,6 +188,6 @@ func (i *infoPrinter) PrintBills(page int) {
 		return
 	}
 	for _, record := range records {
-		console.InfoF("\t#%8s\t%s\t%sR\t%s\n", record.ID, record.Date, record.Cost, record.Traffic)
+		console.InfoF("\t#%8s\t%s\t%.2fR\t%s\n", record.ID, record.Date, record.Cost, record.Traffic)
 	}
 }

--- a/pkg/cmd/info.go
+++ b/pkg/cmd/info.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/neucn/ipgw/pkg/console"
 	"github.com/neucn/ipgw/pkg/handler"
-	"github.com/neucn/ipgw/pkg/model"
 	"github.com/urfave/cli/v2"
 )
 
@@ -40,29 +38,10 @@ var (
 			&cli.IntFlag{Name: "log", Aliases: []string{"l"}, Value: 1, Usage: "print the specific `page` of usage logs"},
 		},
 		Action: func(ctx *cli.Context) error {
-			store, err := getStoreHandler(ctx)
+			account, err := getAccountByContext(ctx)
 			if err != nil {
 				return err
 			}
-			var account *model.Account
-			if u := ctx.String("username"); u == "" {
-				// use stored default account
-				if account = store.Config.GetDefaultAccount(); account == nil {
-					return errors.New("no stored account\n\tplease provide username and password")
-				}
-			} else if p := ctx.String("password"); p == "" {
-				// use stored account
-				if account = store.Config.GetAccount(u); account == nil {
-					return fmt.Errorf("account '%s' not found", u)
-				}
-			} else {
-				// use username and password
-				account = &model.Account{
-					Username: u,
-					Password: p,
-				}
-			}
-			account.Secret = ctx.String("secret")
 			h := handler.NewDashboardHandler()
 			if err := h.Login(account); err != nil {
 				return fmt.Errorf("fail to login:\n\t%v", err)

--- a/pkg/cmd/kick.go
+++ b/pkg/cmd/kick.go
@@ -8,16 +8,45 @@ import (
 
 var (
 	KickCommand = &cli.Command{
-		Name:      "kick",
-		Usage:     "logout any specific device by SID",
-		ArgsUsage: "[sid list]",
+		Name:                   "kick",
+		Usage:                  "logout any specific device by SID",
+		ArgsUsage:              "[sid list]",
+		UseShortOptionHandling: true,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "username",
+				Aliases: []string{"u"},
+				Usage:   "student number `id` (required only if not use the default or first stored account)",
+			},
+			&cli.StringFlag{
+				Name:    "password",
+				Aliases: []string{"p"},
+				Usage:   "`password` for pass.neu.edu.cn (required only if account is not stored)",
+			},
+			&cli.StringFlag{
+				Name:    "secret",
+				Aliases: []string{"s"},
+				Usage:   "`secret` for stored account (required only if secret is not empty)",
+			},
+		},
 		Action: func(ctx *cli.Context) error {
 			sids := ctx.Args().Slice()
 			if len(sids) == 0 {
 				console.InfoL("no sid")
 				return nil
 			}
+			account, err := getAccountByContext(ctx)
+			if err != nil {
+				return err
+			}
 			h := handler.NewIpgwHandler()
+			password, err := account.GetPassword()
+			if err != nil {
+				return err
+			}
+			if err = h.NEUAuth(account.Username, password); err != nil {
+				return err
+			}
 			for _, sid := range sids {
 				result, err := h.Kick(sid)
 				if result {

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+
 	"github.com/neucn/ipgw/pkg/console"
 	"github.com/neucn/ipgw/pkg/handler"
 	"github.com/neucn/ipgw/pkg/model"
@@ -39,11 +40,6 @@ var (
 				Aliases: []string{"i"},
 				Usage:   "output account info after login successfully",
 			},
-			&cli.BoolFlag{
-				Name:    "old",
-				Aliases: []string{"o"},
-				Usage:   "use old login method (non-unified)",
-			},
 		},
 		Action: func(ctx *cli.Context) error {
 			store, err := getStoreHandler(ctx)
@@ -71,9 +67,8 @@ var (
 			} else {
 				// use username and password
 				account = &model.Account{
-					Username:   u,
-					Password:   p,
-					NonUnified: ctx.Bool("old"),
+					Username: u,
+					Password: p,
 				}
 			}
 			account.Secret = ctx.String("secret")

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -42,37 +42,10 @@ var (
 			},
 		},
 		Action: func(ctx *cli.Context) error {
-			store, err := getStoreHandler(ctx)
+			account, err := getAccountByContext(ctx)
 			if err != nil {
 				return err
 			}
-
-			var account *model.Account
-			if c := ctx.String("cookie"); c != "" {
-				// use cookie
-				account = &model.Account{
-					Cookie: c,
-				}
-			} else if u := ctx.String("username"); u == "" {
-				// use stored default account
-				if account = store.Config.GetDefaultAccount(); account == nil {
-					return errors.New("no stored account\n\tplease provide username and password")
-				}
-				console.InfoF("using account '%s'\n", account.Username)
-			} else if p := ctx.String("password"); p == "" {
-				// use stored account
-				if account = store.Config.GetAccount(u); account == nil {
-					return fmt.Errorf("account '%s' not found", u)
-				}
-			} else {
-				// use username and password
-				account = &model.Account{
-					Username: u,
-					Password: p,
-				}
-			}
-			account.Secret = ctx.String("secret")
-
 			h := handler.NewIpgwHandler()
 			if err = login(h, account); err != nil {
 				return fmt.Errorf("login failed: \n\t%v", err)

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -23,7 +23,7 @@ var (
 			&cli.StringFlag{
 				Name:    "password",
 				Aliases: []string{"p"},
-				Usage:   "`password` for pass.neu.edu.cn or ipgw.neu.edu.cn if use old login method (required only if account is not stored)",
+				Usage:   "`password` for pass.neu.edu.cn (required only if account is not stored)",
 			},
 			&cli.StringFlag{
 				Name:    "cookie",

--- a/pkg/handler/dashboard.go
+++ b/pkg/handler/dashboard.go
@@ -3,13 +3,13 @@ package handler
 import (
 	"errors"
 	"fmt"
-	"github.com/neucn/ipgw/pkg/model"
-	"github.com/neucn/ipgw/pkg/utils"
-	"github.com/neucn/neugo"
 	"net/http"
 	"regexp"
 	"strconv"
-	"strings"
+
+	"github.com/neucn/ipgw/pkg/model"
+	"github.com/neucn/ipgw/pkg/utils"
+	"github.com/neucn/neugo"
 )
 
 type DashboardHandler struct {
@@ -32,11 +32,15 @@ func (d *DashboardHandler) Login(account *model.Account) error {
 	if err != nil {
 		return err
 	}
+	_, err = d.client.Get("https://pass.neu.edu.cn/tpass/login?service=http://ipgw.neu.edu.cn:8800/sso/neusoft/index") // 统一认证获取cookie
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
 func (d *DashboardHandler) fetchDashboardIndexBody() (string, error) {
-	resp, err := d.client.Get("http://ipgw.neu.edu.cn:8800/sso/default/neusoft")
+	resp, err := d.client.Get("http://ipgw.neu.edu.cn:8800/home")
 	if err != nil {
 		return "", err
 	}
@@ -44,7 +48,7 @@ func (d *DashboardHandler) fetchDashboardIndexBody() (string, error) {
 }
 
 func (d *DashboardHandler) fetchDashboardBillsBody(page int) (string, error) {
-	resp, err := d.client.Get(fmt.Sprintf("http://ipgw.neu.edu.cn:8800/financial/checkout/list?page=%d&per-page=10", page))
+	resp, err := d.client.Get(fmt.Sprintf("http://ipgw.neu.edu.cn:8800/log/check-out?page=%d&per-page=10", page))
 	if err != nil {
 		return "", err
 	}
@@ -52,7 +56,7 @@ func (d *DashboardHandler) fetchDashboardBillsBody(page int) (string, error) {
 }
 
 func (d *DashboardHandler) fetchDashboardRechargeBody(page int) (string, error) {
-	resp, err := d.client.Get(fmt.Sprintf("http://ipgw.neu.edu.cn:8800/financial/pay/list?page=%d&per-page=10", page))
+	resp, err := d.client.Get(fmt.Sprintf("http://ipgw.neu.edu.cn:8800/log/pay?page=%d&per-page=10", page))
 	if err != nil {
 		return "", err
 	}
@@ -60,7 +64,7 @@ func (d *DashboardHandler) fetchDashboardRechargeBody(page int) (string, error) 
 }
 
 func (d *DashboardHandler) fetchDashboardUsageLogBody(page int) (string, error) {
-	resp, err := d.client.Get(fmt.Sprintf("http://ipgw.neu.edu.cn:8800/log/detail/index?page=%d&per-page=20", page))
+	resp, err := d.client.Get(fmt.Sprintf("http://ipgw.neu.edu.cn:8800/log/detail?page=%d&per-page=10", page))
 	if err != nil {
 		return "", err
 	}
@@ -88,8 +92,8 @@ func (d *DashboardHandler) GetBasic() (*Basic, error) {
 	if err != nil {
 		return nil, err
 	}
-	id, _ := utils.MatchSingle(regexp.MustCompile(`账号</label>\s+(\d+)\s+`), body)
-	name, _ := utils.MatchSingle(regexp.MustCompile(`姓名</label>\s+(.+?)\s+`), body)
+	id, _ := utils.MatchSingle(regexp.MustCompile(`用户名</label>(.+?)</li>`), body)
+	name, _ := utils.MatchSingle(regexp.MustCompile(`姓名</label>(.+?)</li>`), body)
 	return &Basic{
 		ID:   id,
 		Name: name,
@@ -97,17 +101,12 @@ func (d *DashboardHandler) GetBasic() (*Basic, error) {
 }
 
 type Package struct {
-	// Unit is G
-	PackageTraffic string
-	PackageCost    string
-	UsedTraffic    string
-	UsedDuration   string
-	UsedTimes      string
-	Balance        string
+	PackageCost  string
+	UsedTraffic  string
+	UsedDuration string
+	Balance      string
 	// Balance < 0
 	Overdue bool
-	// UsedTraffic > PackageTraffic
-	ExcessPackageTraffic bool
 }
 
 func (d *DashboardHandler) GetPackage() (*Package, error) {
@@ -116,38 +115,22 @@ func (d *DashboardHandler) GetPackage() (*Package, error) {
 		return nil, err
 	}
 
-	infos, _ := utils.MatchMultiple(regexp.MustCompile(`<td>\W+.+?(\d+?)G下行流量(.+?)元?/.+?</td>\W+<td>\W+(.+?)\W+</td>\W+<td>(.+?)</td>\W+<td>(.+?)</td>\W+<td>.+?</td>\W+<td>(.+?)</td>\W+<td>.+?</td>`), body)
+	infos, _ := utils.MatchMultiple(regexp.MustCompile(`<td data-col-seq="3">(.+?)</td><td data-col-seq="4">(.+?)</td><td data-col-seq="6">(.+?)</td><td data-col-seq="7">(.+?)</td></tr>`), body)
 	if len(infos) < 1 {
 		return nil, errors.New("fail to get package info")
 	}
 	info := infos[0]
 
 	result := &Package{
-		UsedTraffic:  info[3],
-		UsedDuration: info[4],
-		UsedTimes:    info[5],
-		Balance:      info[6],
+		UsedTraffic:  info[1],
+		UsedDuration: info[2],
+		PackageCost:  info[3],
+		Balance:      info[4],
 	}
 
-	b, _ := strconv.ParseFloat(info[6], 32)
+	b, _ := strconv.ParseFloat(info[4], 32)
 	if b < 0 {
 		result.Overdue = true
-	}
-
-	result.PackageTraffic = info[1]
-
-	if info[2] == "免费" {
-		result.PackageCost = "0"
-	} else {
-		result.PackageCost = info[2]
-	}
-
-	if strings.HasSuffix(info[3], "G") {
-		u, _ := strconv.ParseFloat(strings.TrimSuffix(info[6], "G"), 32)
-		t, _ := strconv.ParseFloat(info[1], 32)
-		if u > t {
-			result.ExcessPackageTraffic = true
-		}
 	}
 
 	return result, nil
@@ -165,17 +148,17 @@ func (d *DashboardHandler) GetDevice() ([]Device, error) {
 	if err != nil {
 		return []Device{}, err
 	}
-	ds, _ := utils.MatchMultiple(regexp.MustCompile(`<td>\d+</td>\W+?<td>(.+?)</td>\W+?<td>.+?</td>\W+?<td>(.+?)</td>\W+?<td>.+?</td>\W+?<td><a id="(\d+)".+?下线</a></td>`), body)
+	ds, _ := utils.MatchMultiple(regexp.MustCompile(`<tr data-key="(\d+)"><td data-col-seq="0">\d+</td><td data-col-seq="1">(.+?)</td><td data-col-seq="3">(.+?)</td><td data-col-seq="4">.+?</td><td data-col-seq="5">.+?</td>`), body)
 	result := make([]Device, len(ds))
 	for i, device := range ds {
-		result[i] = Device{i, device[1], device[2], device[3]}
+		result[i] = Device{i, device[2], device[3], device[1]}
 	}
 	return result, nil
 }
 
 type BillRecord struct {
 	ID           string
-	Cost         string
+	Cost         float64
 	Traffic      string
 	UsedDuration string
 	Date         string
@@ -191,13 +174,17 @@ func (d *DashboardHandler) GetBill(page int) ([]BillRecord, error) {
 		return []BillRecord{}, errors.New("error occurs when parsing bill page")
 	}
 
-	bills, _ := utils.MatchMultiple(regexp.MustCompile(`<td>(\d+?)</td><td>\d+?</td><td>(\d+?)</td><td>.+?</td><td>.+?</td><td>(.+?)</td><td>(.+?)</td><td>.+?</td><td>(.+?)</td>`), body)
+	bills, _ := utils.MatchMultiple(regexp.MustCompile(`<td data-col-seq="0">(\d+)</td><td data-col-seq="1">.+?</td><td data-col-seq="2">(.+?)</td><td data-col-seq="3">(.+?)</td><td style="display: none;" data-col-seq="6">.+?</td><td data-col-seq="7">(.+?)</td><td data-col-seq="10">(\d+)</td><td data-col-seq="12">(.+?)</td></tr>`), body)
 
 	// b1   b2    b3       b4    b5
 	// id  cost  traffic  time  date
 	result := make([]BillRecord, len(bills))
+
 	for i, b := range bills {
-		result[i] = BillRecord{b[1], b[2], b[3], b[4], strings.Split(b[5], " ")[0]}
+		// 总消费为固定费用+实时费用
+		fixedCost, _ := strconv.ParseFloat(b[2], 32)
+		realtimeCost, _ := strconv.ParseFloat(b[3], 32)
+		result[i] = BillRecord{b[1], fixedCost + realtimeCost, b[4], b[5], b[6]}
 	}
 	return result, nil
 }
@@ -220,7 +207,7 @@ func (d *DashboardHandler) GetUsageRecords(page int) ([]UsageRecord, error) {
 		return []UsageRecord{}, errors.New("error occurs when parsing usage log page")
 	}
 
-	hs, _ := utils.MatchMultiple(regexp.MustCompile(`<td>\d+?</td><td>(.+?)</td><td>(.+?)</td><td>(.+?)</td><td>(.+?)</td><td>(.+?)</td><td>.+?</td></tr>`), body)
+	hs, _ := utils.MatchMultiple(regexp.MustCompile(`<td data-col-seq="1">(.+?)</td><td data-col-seq="2">(.+?)</td><td data-col-seq="5">(.+?)</td><td data-col-seq="10">.+?</td><td data-col-seq="12">.+?</td><td style="display: none;" data-col-seq="14">.+?</td><td data-col-seq="15">(.+?)</td><td style="display: none;" data-col-seq="16">.+?</td><td data-col-seq="17">(.+?)</td><td data-col-seq="18">.+?</td></tr>`), body)
 	result := make([]UsageRecord, len(hs))
 	for i, h := range hs {
 		result[i] = UsageRecord{h[1], h[2], h[3], h[4], h[5]}
@@ -229,10 +216,9 @@ func (d *DashboardHandler) GetUsageRecords(page int) ([]UsageRecord, error) {
 }
 
 type RechargeRecord struct {
-	ID     string
-	Cost   string
-	Method string
-	Time   string
+	ID   string
+	Cost string
+	Time string
 }
 
 func (d *DashboardHandler) GetRecharge(page int) ([]RechargeRecord, error) {
@@ -245,13 +231,13 @@ func (d *DashboardHandler) GetRecharge(page int) ([]RechargeRecord, error) {
 		return []RechargeRecord{}, errors.New("error occurs when parsing recharge page")
 	}
 
-	rs, _ := utils.MatchMultiple(regexp.MustCompile(`<td>(\d+?)</td><td>\d+?</td><td>(\d+?)</td><td>.+?</td><td>(.+?)</td><td>.+?</td><td>(.+?)</td><td>.+?</td>`), body)
+	rs, _ := utils.MatchMultiple(regexp.MustCompile(`<td data-col-seq="0">(.+?)</td><td data-col-seq="1">\d+</td><td data-col-seq="2">(.+?)</td><td data-col-seq="3">.+?</td><td data-col-seq="6">(.+?)</td></tr>`), body)
 
 	result := make([]RechargeRecord, len(rs))
-	// r1  r2     r3      r4
-	// id  cost  method  time
+	// r1  r2     r3
+	// id  cost  time
 	for i, r := range rs {
-		result[i] = RechargeRecord{r[1], r[2], r[3], r[4]}
+		result[i] = RechargeRecord{r[1], r[2], r[3]}
 	}
 	return result, nil
 }

--- a/pkg/handler/dashboard.go
+++ b/pkg/handler/dashboard.go
@@ -32,7 +32,7 @@ func (d *DashboardHandler) Login(account *model.Account) error {
 	if err != nil {
 		return err
 	}
-	_, err = d.client.Get("https://pass.neu.edu.cn/tpass/login?service=http://ipgw.neu.edu.cn:8800/sso/neusoft/index") // 统一认证获取cookie
+	_, err = d.client.Get("http://ipgw.neu.edu.cn:8800/sso/neusoft/index") // 统一认证获取cookie
 	if err != nil {
 		return err
 	}

--- a/pkg/handler/dashboard.go
+++ b/pkg/handler/dashboard.go
@@ -148,7 +148,7 @@ func (d *DashboardHandler) GetDevice() ([]Device, error) {
 	if err != nil {
 		return []Device{}, err
 	}
-	ds, _ := utils.MatchMultiple(regexp.MustCompile(`<tr data-key="(\d+)"><td data-col-seq="0">\d+</td><td data-col-seq="1">(.+?)</td><td data-col-seq="3">(.+?)</td><td data-col-seq="4">.+?</td><td data-col-seq="5">.+?</td>`), body)
+	ds, _ := utils.MatchMultiple(regexp.MustCompile(`<tr data-key="(\d+)"><td data-col-seq="0">\d+</td><td data-col-seq="1">(.+?)</td><td data-col-seq="3">(.+?)</td><td data-col-seq="9"></td>`), body)
 	result := make([]Device, len(ds))
 	for i, device := range ds {
 		result[i] = Device{i, device[2], device[3], device[1]}

--- a/pkg/handler/ipgw.go
+++ b/pkg/handler/ipgw.go
@@ -160,7 +160,7 @@ func (h *IpgwHandler) IsConnectedAndLoggedIn() (connected bool, loggedIn bool) {
 
 func (h *IpgwHandler) Kick(sid string) (bool, error) {
 	once.Do(func() {
-		h.client.Get("https://pass.neu.edu.cn/tpass/login?service=http://ipgw.neu.edu.cn:8800/sso/neusoft/index")
+		h.client.Get("http://ipgw.neu.edu.cn:8800/sso/neusoft/index")
 	})
 	// 请求主页
 	resp, err := h.client.Get("http://ipgw.neu.edu.cn:8800/home")

--- a/pkg/handler/ipgw.go
+++ b/pkg/handler/ipgw.go
@@ -113,7 +113,11 @@ func (h *IpgwHandler) getJsonIpgwData() error {
 }
 
 func getUsernameAndIPFromJson(data map[string]interface{}) (username, ip string) {
-	if data["error"].(string) != "ok" {
+	errorMsg, ok := data["error"].(string)
+	if !ok {
+		return "", ""
+	}
+	if errorMsg != "ok" {
 		return "", data["client_ip"].(string)
 	}
 	return data["user_name"].(string), data["online_ip"].(string)

--- a/pkg/model/account.go
+++ b/pkg/model/account.go
@@ -2,7 +2,7 @@ package model
 
 import (
 	"errors"
-	"fmt"
+
 	"github.com/neucn/ipgw/pkg/utils"
 )
 
@@ -12,7 +12,6 @@ type Account struct {
 	Cookie            string `json:"-"`
 	Secret            string `json:"-"`
 	EncryptedPassword string `json:"encrypted_password"`
-	NonUnified        bool   `json:"non_unified"`
 }
 
 func (a *Account) GetPassword() (string, error) {
@@ -40,8 +39,5 @@ func (a *Account) SetPassword(password string, secret []byte) error {
 }
 
 func (a *Account) String() string {
-	if a.NonUnified {
-		return fmt.Sprintf("%s [non-unified]", a.Username)
-	}
 	return a.Username
 }

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -7,7 +7,7 @@ type Config struct {
 	Accounts       []*Account `json:"accounts"`
 }
 
-func (c *Config) AddAccount(username, password, secret string, nonUnified bool) error {
+func (c *Config) AddAccount(username, password, secret string) error {
 	encryptedPassword, err := utils.Encrypt([]byte(password), []byte(secret))
 	if err != nil {
 		return err

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -15,7 +15,6 @@ func (c *Config) AddAccount(username, password, secret string, nonUnified bool) 
 	c.Accounts = append(c.Accounts, &Account{
 		Username:          username,
 		EncryptedPassword: encryptedPassword,
-		NonUnified:        nonUnified,
 	})
 	return nil
 }


### PR DESCRIPTION
关于#36，已适配： 
- [x] 网关操作
	- [x] 登录
	- [x] 登陆后获取连接信息
	- [x] 下线
	- [x] 测试校园网环境（是否已登录，是否在校园网内）
- [x] 数据查询
	- [x] 套餐信息
	- [x] 已登录设备信息
	- [x] 登录日志
	- [x] 充值信息
	- [x] 扣费信息

除此之外：
- [x] 完成`kick`功能（现需要统一认证）

另：
+ 该pr移除了已弃用的非统一身份认证。
+ 当前[ipgw自助服务平台](http://ipgw.neu.edu.cn:8800/home)尚未稳定，例如昨晚网站在`http/https`间反复横跳，今天上午在线设备展示方式更新等，近期可能还会有变动，待观望。
+ 当前对于欠费的判断方式是尝试登录，登录后判断`api`信息中`user_balance`字段是否小于0，不过欠费后也可能直接登录失败，暂不清楚网关如何处理。~等这月月底我欠费后试一下~。