### PR TITLE
[fix] 不同网络环境需要不同的ac_id

### DIFF
--- a/pkg/handler/ipgw.go
+++ b/pkg/handler/ipgw.go
@@ -112,7 +112,10 @@ func (h *IpgwHandler) requestLoginApi() (string, error) {
 	}
 	// 使用ticket调用api登录
 	req, _ := http.NewRequest("GET", "https://ipgw.neu.edu.cn/v1"+resp.Request.URL.RequestURI(), nil)
-	resp, _ = h.client.Do(req)
+	resp, err = h.client.Do(req)
+	if err != nil {
+		return "", err
+	}
 	return utils.ReadBody(resp), nil
 }
 

--- a/pkg/handler/ipgw.go
+++ b/pkg/handler/ipgw.go
@@ -100,8 +100,13 @@ func (h *IpgwHandler) FetchUsageInfo() error {
 }
 
 func (h *IpgwHandler) requestLoginApi() (string, error) {
+	// 获取当前网络下对应网关url的query参数
+	resp, err := h.client.Get("https://ipgw.neu.edu.cn/index_1.html")
+	if err != nil {
+		return "", err
+	}
 	// 统一认证拿到ticket
-	resp, err := h.client.Get("https://pass.neu.edu.cn/tpass/login?service=http://ipgw.neu.edu.cn/srun_portal_sso?ac_id=1")
+	resp, err = h.client.Get("https://pass.neu.edu.cn/tpass/login?service=http://ipgw.neu.edu.cn/srun_portal_sso?" + resp.Request.URL.RawQuery)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/handler/ipgw.go
+++ b/pkg/handler/ipgw.go
@@ -101,7 +101,7 @@ func (h *IpgwHandler) FetchUsageInfo() error {
 
 func (h *IpgwHandler) requestLoginApi() (string, error) {
 	// 获取当前网络下对应网关url的query参数
-	resp, err := h.client.Get("https://ipgw.neu.edu.cn/index_1.html")
+	resp, err := h.client.Get("https://ipgw.neu.edu.cn/")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
### 问题版本

ipgw v0.2.0-beta+2021-11-03T15:25:14+0000
操作系统：Windows 10 21H1 19043.1288

### 现象

在浑南图书馆 NEU 无线网环境下使用 ipgw 工具登录，显示已登录成功，但是 ping 不通公网，公网网页也无法打开

![image-20211105143103108.png](https://i.loli.net/2021/11/05/iElMLIjhfxcPBZT.png)

### 问题定位

经本人测试，拉取最新 master 分支代码，将 `/pkg/handler/ipgw.go` 104 行 url 中的 ac_id=1 改为 ac_id=15 即可
https://github.com/neucn/ipgw/blob/f2a568a3aea2d343b74de55952f2dbef5c6250bf/pkg/handler/ipgw.go#L104

### 原因推测

在浑南图书馆 NEU 无线网环境下正常打开 ipgw 网关页面 `https://ipgw.neu.edu.cn/ `，可见其 url 参数为 ac_id=15

![image-20211105143358333.png](https://i.loli.net/2021/11/05/qFd6E3HDsgaGOpb.png)

这个参数不可能凭空出现，抓包可见，访问 ipgw 网关主页面后，会先访问 `https://ipgw.neu.edu.cn/index_1.html` 这个页面，之后根据返回的302重定向来跳转至正确的 ac_id 带参页面

![image-20211105143408766.png](https://i.loli.net/2021/11/05/sI2XJ4VoPbOU16w.png)

### 代码修改

据此，我对代码进行了一次修改，在进行统一认证前先访问 `https://ipgw.neu.edu.cn/index_1.html` 拿到对应的 ac_id 参数，之后进行正常的统一认证登录。

目前经个人测试已经解决图书馆 NEU 无线网的登录问题，理论上也能自适应其它网络环境

