### PR TITLE
[fix] 修复下线指定设备失败、在线设备显示不全的问题

### DIFF
--- a/pkg/handler/dashboard.go
+++ b/pkg/handler/dashboard.go
@@ -32,7 +32,7 @@ func (d *DashboardHandler) Login(account *model.Account) error {
 	if err != nil {
 		return err
 	}
-	_, err = d.client.Get("http://ipgw.neu.edu.cn:8800/sso/neusoft/index") // 统一认证获取cookie
+	_, err = d.client.Get("https://ipgw.neu.edu.cn:8800/sso/neusoft/index") // 统一认证获取cookie
 	if err != nil {
 		return err
 	}
@@ -40,7 +40,7 @@ func (d *DashboardHandler) Login(account *model.Account) error {
 }
 
 func (d *DashboardHandler) fetchDashboardIndexBody() (string, error) {
-	resp, err := d.client.Get("http://ipgw.neu.edu.cn:8800/home")
+	resp, err := d.client.Get("https://ipgw.neu.edu.cn:8800/home")
 	if err != nil {
 		return "", err
 	}
@@ -48,7 +48,7 @@ func (d *DashboardHandler) fetchDashboardIndexBody() (string, error) {
 }
 
 func (d *DashboardHandler) fetchDashboardBillsBody(page int) (string, error) {
-	resp, err := d.client.Get(fmt.Sprintf("http://ipgw.neu.edu.cn:8800/log/check-out?page=%d&per-page=10", page))
+	resp, err := d.client.Get(fmt.Sprintf("https://ipgw.neu.edu.cn:8800/log/check-out?page=%d&per-page=10", page))
 	if err != nil {
 		return "", err
 	}
@@ -56,7 +56,7 @@ func (d *DashboardHandler) fetchDashboardBillsBody(page int) (string, error) {
 }
 
 func (d *DashboardHandler) fetchDashboardRechargeBody(page int) (string, error) {
-	resp, err := d.client.Get(fmt.Sprintf("http://ipgw.neu.edu.cn:8800/log/pay?page=%d&per-page=10", page))
+	resp, err := d.client.Get(fmt.Sprintf("https://ipgw.neu.edu.cn:8800/log/pay?page=%d&per-page=10", page))
 	if err != nil {
 		return "", err
 	}
@@ -64,7 +64,7 @@ func (d *DashboardHandler) fetchDashboardRechargeBody(page int) (string, error) 
 }
 
 func (d *DashboardHandler) fetchDashboardUsageLogBody(page int) (string, error) {
-	resp, err := d.client.Get(fmt.Sprintf("http://ipgw.neu.edu.cn:8800/log/detail?page=%d&per-page=10", page))
+	resp, err := d.client.Get(fmt.Sprintf("https://ipgw.neu.edu.cn:8800/log/detail?page=%d&per-page=10", page))
 	if err != nil {
 		return "", err
 	}
@@ -148,7 +148,7 @@ func (d *DashboardHandler) GetDevice() ([]Device, error) {
 	if err != nil {
 		return []Device{}, err
 	}
-	ds, _ := utils.MatchMultiple(regexp.MustCompile(`<tr data-key="(\d+)"><td data-col-seq="0">\d+</td><td data-col-seq="1">(.+?)</td><td data-col-seq="3">(.+?)</td><td data-col-seq="9"></td>`), body)
+	ds, _ := utils.MatchMultiple(regexp.MustCompile(`<tr data-key="(\d+)"><td data-col-seq="0">\d+</td><td data-col-seq="1">(.+?)</td><td data-col-seq="3">(.+?)</td><td data-col-seq="9">.+?</td>`), body)
 	result := make([]Device, len(ds))
 	for i, device := range ds {
 		result[i] = Device{i, device[2], device[3], device[1]}

--- a/pkg/handler/ipgw.go
+++ b/pkg/handler/ipgw.go
@@ -143,7 +143,7 @@ func (h *IpgwHandler) ParseBasicInfo() error {
 
 func (h *IpgwHandler) Logout() error {
 	req, _ := http.NewRequest("GET", "https://ipgw.neu.edu.cn/cgi-bin/srun_portal?action=logout&username="+h.info.Username, nil)
-	req.Header.Add("Referer", "http://ipgw.neu.edu.cn/srun_portal_success?ac_id=1")
+	req.Header.Add("Referer", "https://ipgw.neu.edu.cn/srun_portal_success?ac_id=1")
 	_, err := h.client.Do(req)
 	return err
 }
@@ -160,10 +160,10 @@ func (h *IpgwHandler) IsConnectedAndLoggedIn() (connected bool, loggedIn bool) {
 
 func (h *IpgwHandler) Kick(sid string) (bool, error) {
 	once.Do(func() {
-		h.client.Get("http://ipgw.neu.edu.cn:8800/sso/neusoft/index")
+		h.client.Get("https://ipgw.neu.edu.cn:8800/sso/neusoft/index")
 	})
 	// 请求主页
-	resp, err := h.client.Get("http://ipgw.neu.edu.cn:8800/home")
+	resp, err := h.client.Get("https://ipgw.neu.edu.cn:8800/home")
 	if err != nil {
 		return false, err
 	}
@@ -171,8 +171,8 @@ func (h *IpgwHandler) Kick(sid string) (bool, error) {
 	// 获取csrf-token
 	token, _ := utils.MatchSingle(regexp.MustCompile(`<meta name="csrf-token" content="(.+?)">`), body)
 
-	req, _ := http.NewRequest("POST", "http://ipgw.neu.edu.cn:8800/home/delete?id="+sid, strings.NewReader("_csrf-8800="+token))
-	req.Header.Set("Referer", "http://ipgw.neu.edu.cn:8800/home/index")
+	req, _ := http.NewRequest("POST", "https://ipgw.neu.edu.cn:8800/home/delete?id="+sid, strings.NewReader("_csrf-8800="+token))
+	req.Header.Set("Referer", "https://ipgw.neu.edu.cn:8800/home/index")
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err = h.client.Do(req)


### PR DESCRIPTION
该 PR 修复两个问题：
1. **`ipgw kick SID`失败**

	在 #37 后，[IPGW 自助服务平台](https://ipgw.neu.edu.cn:8800)完成了 https 配置，且为 http 配置了 302 跳转。这导致`ipgw kick`的 POST 请求被重定向为了 GET ，致使请求失败。该 PR 除修改 kick 的 POST 地址外，还将所有涉及该平台的请求地址修改为了 https 。

2. **`ipgw info -d`不显示带有MAC地址的设备**

	正则表达式中误将 MAC 位置留空，已修复。