### PR TITLE
[fix] 更新校园网欠费的判断

### DIFF
--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -60,9 +60,6 @@ var (
 					info.FormattedBalance(),
 					info.FormattedTraffic(),
 					info.FormattedUsedTime())
-				if info.Overdue {
-					console.InfoL("\t状态\t已欠费")
-				}
 			}
 			return nil
 		},
@@ -83,9 +80,6 @@ func login(h *handler.IpgwHandler, account *model.Account) error {
 		return err
 	}
 	info := h.GetInfo()
-	if info.Overdue {
-		return fmt.Errorf("overdue")
-	}
 	if info.Username == "" {
 		return fmt.Errorf("unknown reason")
 	}

--- a/pkg/handler/ipgw.go
+++ b/pkg/handler/ipgw.go
@@ -57,12 +57,12 @@ func (h *IpgwHandler) Login(account *model.Account) error {
 		body, err = h.login(account.Username, password) // 通过用户名、密码登录
 	}
 
-	if strings.Contains(body, "Arrearage users") {
-		return fmt.Errorf("overdue")
-	}
-
 	if err != nil {
 		return err
+	}
+
+	if strings.Contains(body, "Arrearage users") {
+		return fmt.Errorf("overdue")
 	}
 
 	return h.ParseBasicInfo() // 解析信息

--- a/pkg/handler/ipgw.go
+++ b/pkg/handler/ipgw.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -43,16 +44,21 @@ func NewIpgwHandler() *IpgwHandler {
 func (h *IpgwHandler) Login(account *model.Account) error {
 	var (
 		password string
+		body     string
 		err      error
 	)
 	if account.Cookie != "" {
-		_, err = h.loginCookie(account.Cookie) // 通过cookie登录
+		body, err = h.loginCookie(account.Cookie) // 通过cookie登录
 	} else {
 		password, err = account.GetPassword()
 		if err != nil {
 			return err
 		}
-		_, err = h.login(account.Username, password) // 通过用户名、密码登录
+		body, err = h.login(account.Username, password) // 通过用户名、密码登录
+	}
+
+	if strings.Contains(body, "Arrearage users") {
+		return fmt.Errorf("overdue")
 	}
 
 	if err != nil {
@@ -145,7 +151,6 @@ func getUsernameAndIPFromJson(data map[string]interface{}) (username, ip string)
 func (h *IpgwHandler) ParseBasicInfo() error {
 	h.getJsonIpgwData()
 	h.info.Username, h.info.IP = getUsernameAndIPFromJson(h.oriInfo)
-	h.info.Overdue = h.oriInfo["user_balance"].(float64) < 0
 	return nil
 }
 

--- a/pkg/model/info.go
+++ b/pkg/model/info.go
@@ -9,7 +9,6 @@ type Info struct {
 	IP                string
 	Traffic, UsedTime int
 	Balance           float64
-	Overdue           bool
 }
 
 func (i *Info) FormattedTraffic() string {


### PR DESCRIPTION
校园网欠费后表现为登录 api 返回错误信息，实际登录未成功。
该 pr 修改了校园网欠费的判断，避免了欠费情况的崩溃问题。